### PR TITLE
Allow calling drawString with empty string.

### DIFF
--- a/src/main/java/com/orsonpdf/PDFGraphics2D.java
+++ b/src/main/java/com/orsonpdf/PDFGraphics2D.java
@@ -623,9 +623,11 @@ public final class PDFGraphics2D extends Graphics2D {
                 this.hints.get(PDFHints.KEY_DRAW_STRING_TYPE))) {
             this.gs.drawString(str, x, y);
         } else {
-            AttributedString as = new AttributedString(str, 
-                    this.font.getAttributes());
-            drawString(as.getIterator(), x, y);
+            if (str.length() > 0) { // avoid IllegalArgumentException for empty string
+                AttributedString as = new AttributedString(str, 
+                        this.font.getAttributes());
+                drawString(as.getIterator(), x, y);
+            }
         }
         
         if (this.clip != null) {


### PR DESCRIPTION
Calling drawString using the orsonpdf backend leads to an exception:

> java.lang.IllegalArgumentException: Can't add attribute to 0-length text

This is different to standard JRE Graphics2D behaviour.