### PR TITLE
Update GraphicsStream.java

### DIFF
--- a/src/main/java/com/orsonpdf/GraphicsStream.java
+++ b/src/main/java/com/orsonpdf/GraphicsStream.java
@@ -2,7 +2,7 @@
  * OrsonPDF : a fast, light-weight PDF library for the Java(tm) platform
  * =====================================================================
  * 
- * (C)opyright 2013-2015, by Object Refinery Limited.  All rights reserved.
+ * (C)opyright 2013-2020, by Object Refinery Limited.  All rights reserved.
  *
  * Project Info:  http://www.object-refinery.com/orsonpdf/index.html
  * 
@@ -488,10 +488,30 @@ public class GraphicsStream extends Stream {
                 // perform "degree elevation":
                 // http://www.cs.mtu.edu/~shene/COURSES/cs3621/NOTES/spline
                 //       /Bezier/bezier-elev.html
+                /*
                 float x0 = 0.25f * lastX + 0.75f * coords[0];
                 float y0 = 0.25f * lastY + 0.75f * coords[1];
                 float x1 = 0.5f * coords[0] + 0.5f * coords[2];
                 float y1 = 0.5f * coords[1] + 0.5f * coords[3];
+                */
+ 
+                // PDF doesn't support quadratic Bézier curves; it only supports
+                // cubic Bézier curves, so we need to perform "degree elevation"
+                // to convert the quadratic Bézier curve into a cubic Bézier
+                // curve. This is the only way to preserve the original curve's
+                // shape accurately for all arbitrary cases.
+                //
+                // https://pages.mtu.edu/~shene/COURSES/cs3621/NOTES/spline/Bezier/bezier-elev.html
+                //
+                // https://en.wikipedia.org/wiki/Bézier_curve#Degree_elevation
+                //
+                // A quadratic curve has degree 2; a cubic curve has degree 3.
+                //
+                // The code is simplified to improve performance and accuracy
+                final float x0 = ( lastX + ( 2f * coords[0] ) ) / 3f;
+                final float y0 = ( lastY + ( 2f * coords[1] ) ) / 3f;
+                final float x1 = ( ( 2f * coords[0] ) + coords[2] ) / 3f;
+                final float y1 = ( ( 2f * coords[1] ) + coords[3] ) / 3f;
                 b.append(geomDP(x0)).append(" ");
                 b.append(geomDP(y0)).append(" ");
                 b.append(geomDP(x1)).append(" ");


### PR DESCRIPTION
Fixed the quadratic to cubic curve "degree elevation" algorithm, which made an incorrect assignment of the degree of a quadratic curve when applying the well-known degree elevation formula for converting to the next degree (cubic in this case).

I spent hours on this to make sure the older code really was in error, doing the equation many different ways to make sure I got the same results each time, and comparing against every implementation I've ever seen for EPS and PDF (SVG supports directly-specific quadratic curves). I have a good feeling for how the coding error happened, as the coordinate transforms WOULD be correct if going to a fourth order curve (and then an extra control point would be needed, still using the same formula).

I augmented the comments but retained the original commenting style and words in order to minimize the overall changes. As the file apparently hadn't been updated since 2015, I also bumped the copyright range to 2020 to cover these new edits.

I did not pull in fixes from other forks, but reviewed them all, and am using the ones that are graphics oriented in my local private branch, but none of them touch the code that I edited tonight so there should be no incompatibilities or conflicts if those other forks by other contributors are merged into the main code base later on.

I have another commit to do tomorrow that is unrelated and isn't part of the graphics handling. I thought it best to decouple the changes in two separate commits, as it is still easy to see the combined changes once the second commit is done.